### PR TITLE
build: use whiskers.filename instead of output redirection

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,4 +2,4 @@ _default:
   @just --list
 
 build:
-  whiskers spotify-player.tera > theme.toml
+  whiskers spotify-player.tera

--- a/spotify-player.tera
+++ b/spotify-player.tera
@@ -1,6 +1,7 @@
 ---
 whiskers:
-  version: 2.1.0
+  version: "2.2.0"
+  filename: "theme.toml"
 ---
 
 {%- for _, flavor in flavors -%}


### PR DESCRIPTION
Simplifies the justfile so that the output file is now written to by Whiskers itself.