### PR TITLE
fix: set component styles again

### DIFF
--- a/spotify-player.tera
+++ b/spotify-player.tera
@@ -31,7 +31,7 @@ bright_yellow = "#{{ palette.yellow.hex }}"
 
 [themes.component_style]
 selection = { bg = "#{{ palette.surface0.hex }}", modifiers = ["Bold"] }
-block_title = { fg = "Magenta"  }
+block_title = { fg = "Magenta" }
 playback_track = { fg = "Cyan", modifiers = ["Bold"] }
 playback_album = { fg = "Yellow" }
 playback_metadata = { fg = "Blue" }

--- a/spotify-player.tera
+++ b/spotify-player.tera
@@ -31,5 +31,17 @@ bright_yellow = "#{{ palette.yellow.hex }}"
 
 [themes.component_style]
 selection = { bg = "#{{ palette.surface0.hex }}", modifiers = ["Bold"] }
+block_title = { fg = "Magenta"  }
+playback_track = { fg = "Cyan", modifiers = ["Bold"] }
+playback_album = { fg = "Yellow" }
+playback_metadata = { fg = "Blue" }
+playback_progress_bar = { bg = "#{{ palette.surface0.hex }}", fg = "Green" }
+current_playing = { fg = "Green", modifiers = ["Bold"] }
+page_desc = { fg = "Cyan", modifiers = ["Bold"] }
+table_header = { fg = "Blue" }
+border = {}
+playback_status = { fg = "Cyan", modifiers = ["Bold"] }
+playback_artists = { fg = "Cyan", modifiers = ["Bold"] }
+playlist_desc = { fg = "#{{ palette.subtext0.hex }}" }
 
 {% endfor -%}

--- a/theme.toml
+++ b/theme.toml
@@ -22,6 +22,18 @@ bright_yellow = "#df8e1d"
 
 [themes.component_style]
 selection = { bg = "#ccd0da", modifiers = ["Bold"] }
+block_title = { fg = "Magenta"  }
+playback_track = { fg = "Cyan", modifiers = ["Bold"] }
+playback_album = { fg = "Yellow" }
+playback_metadata = { fg = "Blue" }
+playback_progress_bar = { bg = "#ccd0da", fg = "Green" }
+current_playing = { fg = "Green", modifiers = ["Bold"] }
+page_desc = { fg = "Cyan", modifiers = ["Bold"] }
+table_header = { fg = "Blue" }
+border = {}
+playback_status = { fg = "Cyan", modifiers = ["Bold"] }
+playback_artists = { fg = "Cyan", modifiers = ["Bold"] }
+playlist_desc = { fg = "#6c6f85" }
 
 [[themes]]
 name = "Catppuccin-frappe"
@@ -47,6 +59,18 @@ bright_yellow = "#e5c890"
 
 [themes.component_style]
 selection = { bg = "#414559", modifiers = ["Bold"] }
+block_title = { fg = "Magenta"  }
+playback_track = { fg = "Cyan", modifiers = ["Bold"] }
+playback_album = { fg = "Yellow" }
+playback_metadata = { fg = "Blue" }
+playback_progress_bar = { bg = "#414559", fg = "Green" }
+current_playing = { fg = "Green", modifiers = ["Bold"] }
+page_desc = { fg = "Cyan", modifiers = ["Bold"] }
+table_header = { fg = "Blue" }
+border = {}
+playback_status = { fg = "Cyan", modifiers = ["Bold"] }
+playback_artists = { fg = "Cyan", modifiers = ["Bold"] }
+playlist_desc = { fg = "#a5adce" }
 
 [[themes]]
 name = "Catppuccin-macchiato"
@@ -72,6 +96,18 @@ bright_yellow = "#eed49f"
 
 [themes.component_style]
 selection = { bg = "#363a4f", modifiers = ["Bold"] }
+block_title = { fg = "Magenta"  }
+playback_track = { fg = "Cyan", modifiers = ["Bold"] }
+playback_album = { fg = "Yellow" }
+playback_metadata = { fg = "Blue" }
+playback_progress_bar = { bg = "#363a4f", fg = "Green" }
+current_playing = { fg = "Green", modifiers = ["Bold"] }
+page_desc = { fg = "Cyan", modifiers = ["Bold"] }
+table_header = { fg = "Blue" }
+border = {}
+playback_status = { fg = "Cyan", modifiers = ["Bold"] }
+playback_artists = { fg = "Cyan", modifiers = ["Bold"] }
+playlist_desc = { fg = "#a5adcb" }
 
 [[themes]]
 name = "Catppuccin-mocha"
@@ -97,4 +133,16 @@ bright_yellow = "#f9e2af"
 
 [themes.component_style]
 selection = { bg = "#313244", modifiers = ["Bold"] }
+block_title = { fg = "Magenta"  }
+playback_track = { fg = "Cyan", modifiers = ["Bold"] }
+playback_album = { fg = "Yellow" }
+playback_metadata = { fg = "Blue" }
+playback_progress_bar = { bg = "#313244", fg = "Green" }
+current_playing = { fg = "Green", modifiers = ["Bold"] }
+page_desc = { fg = "Cyan", modifiers = ["Bold"] }
+table_header = { fg = "Blue" }
+border = {}
+playback_status = { fg = "Cyan", modifiers = ["Bold"] }
+playback_artists = { fg = "Cyan", modifiers = ["Bold"] }
+playlist_desc = { fg = "#a6adc8" }
 

--- a/theme.toml
+++ b/theme.toml
@@ -22,7 +22,7 @@ bright_yellow = "#df8e1d"
 
 [themes.component_style]
 selection = { bg = "#ccd0da", modifiers = ["Bold"] }
-block_title = { fg = "Magenta"  }
+block_title = { fg = "Magenta" }
 playback_track = { fg = "Cyan", modifiers = ["Bold"] }
 playback_album = { fg = "Yellow" }
 playback_metadata = { fg = "Blue" }
@@ -59,7 +59,7 @@ bright_yellow = "#e5c890"
 
 [themes.component_style]
 selection = { bg = "#414559", modifiers = ["Bold"] }
-block_title = { fg = "Magenta"  }
+block_title = { fg = "Magenta" }
 playback_track = { fg = "Cyan", modifiers = ["Bold"] }
 playback_album = { fg = "Yellow" }
 playback_metadata = { fg = "Blue" }
@@ -96,7 +96,7 @@ bright_yellow = "#eed49f"
 
 [themes.component_style]
 selection = { bg = "#363a4f", modifiers = ["Bold"] }
-block_title = { fg = "Magenta"  }
+block_title = { fg = "Magenta" }
 playback_track = { fg = "Cyan", modifiers = ["Bold"] }
 playback_album = { fg = "Yellow" }
 playback_metadata = { fg = "Blue" }
@@ -133,7 +133,7 @@ bright_yellow = "#f9e2af"
 
 [themes.component_style]
 selection = { bg = "#313244", modifiers = ["Bold"] }
-block_title = { fg = "Magenta"  }
+block_title = { fg = "Magenta" }
 playback_track = { fg = "Cyan", modifiers = ["Bold"] }
 playback_album = { fg = "Yellow" }
 playback_metadata = { fg = "Blue" }


### PR DESCRIPTION
this pr re-adds the additions of #1 which were removed in #6.
i've also added the other options from [the available component styles](https://github.com/aome510/spotify-player/blob/master/docs/config.md#component-styles), trying to provide sensible options if needed; suggestions about color changes are very welcome.
closes #11 since nothing except the background is set to `BrightBlack`:
- `playback_metadata` and `playback_progress_bar` are set according to the changes in #1
- `playlist_desc` is set to `subtext0` since i found that to fit well
